### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Responsive Design Bookmarklet Generator
+# Responsive Design Bookmarklet Generator
 
 ## About
 This is a simple script that lets you view any webpage in multiple screen sizes, simulating the viewport of different devices. It works by generating a custom bookmarklet containing whatever screen dimensions you're interested. You can then just click the bookmark to view any current webpage in a variety of sizes. Simple!


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
